### PR TITLE
Delete Hosts header to bypass vhost checks

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -171,6 +171,7 @@ int main(int argc, char *argv[])
                     {
                         headers[header.first] = header.second; // extract all headers from the incoming request
                     }
+                    headers.erase("Host"); // prevent vhosts checks from failing
                     headers.erase("Accept-Encoding");
                     headers.emplace("Accept-Encoding", "identity");
                     cpr::Response r = cpr::Post(node, cpr::Body{body}, headers); // send the request to the node
@@ -198,6 +199,7 @@ int main(int argc, char *argv[])
                     {
                         headers[header.first] = header.second; // extract all headers from the incoming request
                     }
+                    headers.erase("Host"); // prevent vhosts checks from failing
                     headers.erase("Accept-Encoding");
                     headers.emplace("Accept-Encoding", "identity");
                     cpr::Response r = cpr::Post(node, cpr::Body{body}, headers); // send the request to the node
@@ -239,6 +241,7 @@ int main(int argc, char *argv[])
                     {
                         headers[header.first] = header.second; // extract all headers from the incoming request
                     }
+                    headers.erase("Host"); // prevent vhosts checks from failing
                     headers.erase("Accept-Encoding");
                     headers.emplace("Accept-Encoding", "identity");
                     cpr::Response r = cpr::Post(node, cpr::Body{body}, headers); // send the request to the node


### PR DESCRIPTION
This is a change I threw together to reduce vhosts-related errors in the following setup:

- Execution client is configured to accept connections for domain `localhost` only (via e.g. `--authrpc.vhosts=localhost`). This is the default for most execution clients.
- OE is running on localhost
- OE is forwarded to a different host via an SSH tunnel, e.g. 192.168.1.123 or `host.docker.internal`

The fix is to delete the `Host` header sent by the client, so that it gets filled in by the `cpr` library with the execution node's actual host. This assumes that users running OE don't care about vhosts protection for the OE service, but _do care_ about it for the underlying EL.

Alternatives to making this change (untested) are:

- Run a reverse-proxy in front of OE, which munges the host header (is this what you do for your public instance @TennisBowling?).
- Set `--authrpc.vhosts='*'` to disable vhosts checks on the execution client.

Both of these workarounds are quite easy, so I don't mind if we adopt them instead of this PR.